### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/arm32-docker-build.yml
+++ b/.github/workflows/arm32-docker-build.yml
@@ -22,7 +22,7 @@ jobs:
           apt-get update && apt-get install docker.io -y
           mv Dockerfile_arm32 Dockerfile
     - name: Publish to Docker
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         GIT_COMMIT: $(git log -1 --format=%h)
       with:

--- a/.github/workflows/arm64-docker-build.yml
+++ b/.github/workflows/arm64-docker-build.yml
@@ -22,7 +22,7 @@ jobs:
           apt-get update && apt-get install docker.io -y
           mv Dockerfile_alpine_arm64 Dockerfile
     - name: Publish to Docker
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         GIT_COMMIT: $(git log -1 --format=%h)
       with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Unshallow fetching
       run: git fetch --unshallow
     - name: Publish to Docker
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         GIT_COMMIT: $(git log -1 --format=%h)
       with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore